### PR TITLE
refactored away from only allowing a .key for the secret used to sign…

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -5,7 +5,10 @@ SERVER_PORT=8090
 LOG_LEVEL=debug
 
 CORE_DB_CONNECTION_STRING=
-SESSION_SECRET=
+
+# choose only one of these, either a plaintext secret or a filepath to a .key file
+ENCRYPTION_KEY_SECRET=
+ENCRYPTION_KEY_PATH=
 
 # controls which file storage method to use, possible values are azure_blob and filesystem
 FILE_STORAGE_METHOD=filesystem

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -152,7 +152,7 @@ export class Router {
         // fetch set of permissions per resource for the user before returning
         RetrieveResourcePermissions((user as UserT).id!)
             .then((permissions: string[][]) => {
-                const token = jwt.sign(user, fs.readFileSync(Config.encryption_key_path), {expiresIn: '100m'})
+                const token = jwt.sign(user, Config.encryption_key_secret, {expiresIn: '100m'})
 
                 return resp.redirect(req.body.RelayState + `?jwt=${token}`)
             })
@@ -185,7 +185,7 @@ export class Router {
           RetrieveResourcePermissions((user as UserT).id!)
               .then((permissions: string[][]) => {
                   user.permissions = permissions
-                  const token = jwt.sign(user, fs.readFileSync(Config.encryption_key_path), {expiresIn: '100m'})
+                  const token = jwt.sign(user, Config.encryption_key_secret, {expiresIn: '100m'})
                   return resp.redirect(req.body.redirect + `?jwt=${token}`)
               })
 
@@ -223,7 +223,7 @@ export class Router {
                           .then(permissions => {
                               user.value.permissions = permissions
 
-                              const token = jwt.sign(user.value, fs.readFileSync(Config.encryption_key_path), {expiresIn: '101m'})
+                              const token = jwt.sign(user.value, Config.encryption_key_secret, {expiresIn: '101m'})
                               res.status(200).json(token)
                               return
                           })

--- a/src/user_management/authentication/jwt.ts
+++ b/src/user_management/authentication/jwt.ts
@@ -9,7 +9,7 @@ const JwtStrategy = passportJWT.Strategy;
 export function SetJWTAuthMethod(app: express.Application) {
     passport.use(new JwtStrategy({
         jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-        secretOrKey: fs.readFileSync(Config.encryption_key_path)
+        secretOrKey: Config.encryption_key_secret
     }, (jwt, done) => {
             done(null, jwt)
     } ))

--- a/src/user_management/authentication/local.ts
+++ b/src/user_management/authentication/local.ts
@@ -1,10 +1,7 @@
 import express from "express"
-import Config from "../../config"
 import passport from "passport"
 import {Strategy} from "passport-local"
 import UserStorage from "../../data_storage/user_management/user_storage";
-import NodeRSA from "node-rsa";
-import fs from "fs";
 import bcrypt from "bcrypt";
 import Logger from "./../../logger"
 
@@ -14,12 +11,6 @@ export  function SetLocalAuthMethod(app: express.Application) {
             .then(result => {
                 if(result.isError) return done(result.error)
                 if(!result.value) return done("unable to login as provided user")
-
-
-                const key = new NodeRSA(fs.readFileSync(Config.encryption_key_path));
-                const encryptedPassword = key.encryptPrivate(password, "base64");
-
-                if(encryptedPassword === result.value.password) return done(null, result.value)
 
                 bcrypt.compare(password, result.value.password!)
                     .then((match) => {

--- a/src/user_management/authentication/saml/saml-adfs.ts
+++ b/src/user_management/authentication/saml/saml-adfs.ts
@@ -12,14 +12,19 @@ import Result from "../../../result";
 const SamlStrategy = passportSaml.Strategy;
 
 export function SetSamlAdfs(app: express.Application) {
-    passport.serializeUser((user, done) => {
+    // do not set the auth strategy if we don't have a public/private key pair.
+    // If a user attempts to auth with this strategy attempting the login routes
+    // without a public/private key present the application will return an error
+     if(!Config.saml_adfs_private_cert_path || !Config.saml_adfs_public_cert_path) return;
+
+     passport.serializeUser((user, done) => {
         done(null, user);
     });
-    passport.deserializeUser((user, done) => {
+     passport.deserializeUser((user, done) => {
         done(null, user);
     });
 
-    passport.use(new SamlStrategy({
+     passport.use(new SamlStrategy({
         entryPoint: Config.saml_adfs_entry_point,
         issuer: Config.saml_adfs_issuer,
         callbackUrl: Config.saml_adfs_callback,


### PR DESCRIPTION
… things like JWTs

- Refactored away from using a .key file if none is present.
- Application will use a secret string instead of key file if none is present
- SAML will short circuit to failure always when now public/private key is set.