### PR TITLE
general bugfixes - removal of pg_cron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 /src/privateKey.key
 /src/user_management/authentication/saml/localhost.cert
 /src/user_management/authentication/saml/localhost.xml
+/tools/ontology_extractor/diamond.owl

--- a/Dockerfiles/PostgreSQL/Dockerfile
+++ b/Dockerfiles/PostgreSQL/Dockerfile
@@ -1,4 +1,1 @@
 FROM postgres:12
-
-RUN apt-get update \
-    && apt-get -y install postgresql-12-cron

--- a/Dockerfiles/PostgreSQL/deeplynx.conf
+++ b/Dockerfiles/PostgreSQL/deeplynx.conf
@@ -748,5 +748,3 @@ listen_addresses = '*'
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
-shared_preload_libraries = 'pg_cron'
-cron.database_name = 'deep_lynx'

--- a/api_documentation/Core.postman_collection.json
+++ b/api_documentation/Core.postman_collection.json
@@ -222,7 +222,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    nodes {\r\n        id\r\n        metatype {name}\r\n        properties {key value type}\r\n        raw_properties\r\n        outgoing_edges {\r\n            id\r\n            relationship {name description id} \r\n            }\r\n        incoming_edges {id}\r\n       \r\n    }\r\n}"
+							"raw": "{\r\n    nodes(where: {\r\n        AND: [\r\n            {properties: [\r\n            {key: \"notRequired\" value:\"false\" operator:\"like\"}\r\n            ]}\r\n            ]\r\n    }) {\r\n        id\r\n        metatype{id}\r\n        archived\r\n    }\r\n}"
 						},
 						"url": {
 							"raw": "{{baseURL}}/containers/:container-id/query",
@@ -238,7 +238,7 @@
 								{
 									"key": "container-id",
 									"type": "string",
-									"value": ""
+									"value": "20e22d75-338f-4b7d-b3d3-aafaeb1f8621"
 								}
 							]
 						},
@@ -282,7 +282,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"container_id\": \"required\",\r\n    \"original_data_id\": \"optional\",\r\n    \"data_source_id\": \"required\",\r\n    \"data_type_mapping_id\": \"optional\",\r\n    \"metatype_id\": \"required\",\r\n    \"modified_at\": \"optional - set to update node if it exists\",\r\n    \"properties\": {}\r\n}",
+							"raw": "{\r\n    \"container_id\": \"required\",\r\n    \"original_data_id\": \"optional - but required if planning on being able to update the node from this endpoint\",\r\n    \"data_source_id\": \"required\",\r\n    \"data_type_mapping_id\": \"optional\",\r\n    \"metatype_id\": \"required\",\r\n    \"modified_at\": \"optional - set to update node along with the original data id to update if it exists\",\r\n    \"properties\": {}\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1862,7 +1862,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"adapter_type\":\"http\",\n\t\"active\": true,\n\t\"config\": {\n\t\t\"endpoint\":\"\",\n        \"auth_method\":\"basic\",\n        \"username\": \"test\",\n       \"password\": \"test\"\n\t}\n}",
+							"raw": "{\n\t\"name\": \"testing data source\"\n\t\"adapter_type\":\"http OR manual\",\n\t\"active\": true,\n\t\"config\": { // needed only if you are using the HTTP data source\n\t\t\"endpoint\":\"\",\n        \"auth_method\":\"basic\",\n        \"username\": \"test\",\n       \"password\": \"test\"\n\t}\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/migrations/001_containers_basic_meta.sql
+++ b/migrations/001_containers_basic_meta.sql
@@ -28,7 +28,6 @@ CREATE TABLE metatypes (
 
 
 CREATE UNIQUE INDEX metatype_id_pk ON metatypes(id uuid_ops);
-CREATE UNIQUE INDEX metatype_name ON metatypes(name text_ops);
 
 CREATE TABLE metatype_keys (
     metatype_id uuid NOT NULL REFERENCES metatypes(id) ON DELETE CASCADE,

--- a/migrations/009_type_mapping_scheduled_function.sql
+++ b/migrations/009_type_mapping_scheduled_function.sql
@@ -1,5 +1,3 @@
-CREATE EXTENSION pg_cron;
-
 CREATE OR REPLACE FUNCTION set_type_mapping(arg data_type_mappings)
 	RETURNS void
 	language plpgsql
@@ -30,8 +28,6 @@ BEGIN
 
 END;
 $$;
-
-SELECT cron.schedule('* * * * *', $$SELECT set_type_mapping(data_type_mappings) from data_type_mappings$$);
 
 CREATE OR REPLACE FUNCTION set_type_mapping_trigger()
 	RETURNS TRIGGER

--- a/migrations/021_CORRECTION_dropping_unique_relationship_keys.sql
+++ b/migrations/021_CORRECTION_dropping_unique_relationship_keys.sql
@@ -1,0 +1,4 @@
+ALTER TABLE metatypes DROP CONSTRAINT IF EXISTS metatypes_name_key;
+ALTER TABLE metatypes DROP CONSTRAINT IF EXISTS metatype_name;
+
+ALTER TABLE metatypes ADD CONSTRAINT metatypes_name_container_id_un UNIQUE (container_id, name);

--- a/readme.md
+++ b/readme.md
@@ -19,13 +19,12 @@ The construction of megaprojects has consistently demonstrated challenges for pr
 - node.js 12.x 
 - Typescript ^3.5.x
 - npm ^6.x
-- Docker ^18.x - **required** if attempting to run Deep Lynx on a Windows system because the pg_cron PostgreSQL extension cannot be compiled and used on Windows.
-- Docker Compose ^1.x.x - *optional* 
+- Docker ^18.x - *optional* - for ease of use in development
+- Docker Compose ^1.x.x - *optional* - for ease of use in development
 
 ***Data Source Requirements***
 
 - **Required** - PostgreSQL ^11.x 
-- **Required** - pg_cron PostgreSQL extension: Instructions for installation can be found [here](https://github.com/citusdata/pg_cron)
 
 **Installation**
 

--- a/src/api/data_source_routes.ts
+++ b/src/api/data_source_routes.ts
@@ -34,7 +34,7 @@ export default class DataSourceRoutes {
         app.post('/containers/:id/import/datasources/:sourceID/files', ...middleware, authInContainer("write", "data"), this.uploadFile)
 
         app.post('/containers/:id/import/datasources/:sourceID/mappings', ...middleware, authInContainer("write", "data"), this.createTypeMapping)
-        app.get('/containers/:id/import/datasources/:sourceID/mappings/unmapped', ...middleware, authInContainer("read", "data"), this.getUnmappedData)
+        app.get('/containers/:id/import/datasources/:sourceID/mappings/unmapped/data', ...middleware, authInContainer("read", "data"), this.getUnmappedData)
         app.get('/containers/:id/import/datasources/:sourceID/mappings/unmapped/count', ...middleware, authInContainer("read", "data"), this.countUnmappedData)
         app.put('/containers/:id/import/datasources/:sourceID/mappings/:mappingID', ...middleware, authInContainer("write", "data"), this.updateTypeMapping)
         app.get('/containers/:id/import/datasources/:sourceID/mappings/:mappingID', ...middleware, authInContainer("write", "data"), this.retrieveTypeMapping)

--- a/src/data_processing/processing.ts
+++ b/src/data_processing/processing.ts
@@ -169,6 +169,9 @@ export async function StartDataProcessing(): Promise<Result<boolean>> {
     let i = 0
 
     while(true) {
+        // run type mapping set stored procedure - this will assign type mappings if some exist for data currently
+        TypeMappingStorage.Instance.SetAllTypeMappings()
+
         let dataSources: DataSourceT[] = []
 
         // make sure we only ever start one processing loop per active data source

--- a/src/data_storage/import/data_staging_storage.ts
+++ b/src/data_storage/import/data_staging_storage.ts
@@ -94,7 +94,7 @@ export default class DataStagingStorage extends PostgresStorage {
 
     private static countUnprocessedByDataSourceStatement(dataSourceID: string): QueryConfig {
         return {
-            text: `SELECT COUNT(*) FROM data_staging WHERE data_source_id = $1 AND inserted_at IS NULL`,
+            text: `SELECT COUNT(*) FROM data_staging WHERE data_source_id = $1 AND inserted_at IS NULL AND mapping_id IS NULL`,
             values: [dataSourceID]
         }
     }

--- a/src/data_storage/import/type_mapping_storage.ts
+++ b/src/data_storage/import/type_mapping_storage.ts
@@ -89,6 +89,11 @@ export default class TypeMappingStorage extends PostgresStorage{
         return super.retrieve<TypeMappingT>(TypeMappingStorage.retrieveStatement(id))
     }
 
+    // runs a stored procedure which will update data in data staging with type mappings if any match
+    public SetAllTypeMappings(): Promise<Result<boolean>> {
+        return super.run(TypeMappingStorage.setTypeMappingProcedureStatement())
+    }
+
     public List(containerID: string, offset: number, limit: number): Promise<Result<TypeMappingT[]>> {
         return super.rows<TypeMappingT>(TypeMappingStorage.listStatement(containerID, offset, limit))
     }
@@ -138,6 +143,12 @@ export default class TypeMappingStorage extends PostgresStorage{
         return {
             text: `SELECT * FROM data_type_mappings WHERE data_source_id = $1 OFFSET $2 LIMIT $3`,
             values: [dataSourceID, offset, limit]
+        }
+    }
+
+    private static setTypeMappingProcedureStatement(): QueryConfig {
+        return {
+            text: `SELECT set_type_mapping(data_type_mappings) from data_type_mappings`
         }
     }
 }


### PR DESCRIPTION
Quick changes to the metatypes migrations (needed unique on name and container_id combo) and to a couple of routes. Postman updated as well.

I also removed the need for the `pg_cron` extension. I was running into problems with it when dealing with new type mappings. That combined with the hobbling of development by making it impossible to develop Deep Lynx on windows without Postgres made removal of the extension necessary.

**This is a breaking change because I had to modify one of the earlier migration scripts**

## Motivation and Context
After giving a demonstration of Deep Lynx various little bugs and holes were found. Patched these holes.

Ran into issues with the Type Mapping system, so I removed the `pg_cron` extension and let Deep Lynx handle calling the stored procedure itself.

## How Has This Been Tested?
Testing suite ran, rebuilt Docker containers and tried against a pristine database (without `pg_cron` installed)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
