### PR TITLE
Add relationship pair update and archived filter

### DIFF
--- a/api_documentation/Core.postman_collection.json
+++ b/api_documentation/Core.postman_collection.json
@@ -1693,7 +1693,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"name\": \"Relationship Pair Test\",\n\t\"description\": \"Relationship Pair Test description\",\n\t\"origin_metatype_id\": \"566e3862-6853-45af-8a45-3050576dfb9a\",\n\t\"destination_metatype_id\": \"8bcc0b06-bb44-4176-a581-aa68eafca7f3\",\n\t\"metatype_relationship_id\": \"885e3fca-5066-4be8-a720-63b3c4744e97\",\n\t\"relationship_type\": \"many:many\"\n}",
+									"raw": "{\n\t\"name\": \"Relationship Pair Test\",\n\t\"description\": \"Relationship Pair Test description\",\n\t\"origin_metatype_id\": \"566e3862-6853-45af-8a45-3050576dfb9a\",\n\t\"destination_metatype_id\": \"8bcc0b06-bb44-4176-a581-aa68eafca7f3\",\n\t\"relationship_id\": \"885e3fca-5066-4be8-a720-63b3c4744e97\",\n\t\"relationship_type\": \"many:many\"\n}",
 									"options": {
 										"raw": {}
 									}
@@ -1792,6 +1792,46 @@
 									]
 								},
 								"description": "List all Type Relationship Pairs for current container."
+							},
+							"response": []
+						},
+						{
+							"name": "Update Type Relationship Pair",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"name\": \"Relationship Pair Test\",\n\t\"description\": \"Relationship Pair Test description\",\n\t\"origin_metatype_id\": \"566e3862-6853-45af-8a45-3050576dfb9a\",\n\t\"destination_metatype_id\": \"8bcc0b06-bb44-4176-a581-aa68eafca7f3\",\n\t\"relationship_id\": \"885e3fca-5066-4be8-a720-63b3c4744e97\",\n\t\"relationship_type\": \"many:many\"\n}"
+								},
+								"url": {
+									"raw": "{{baseURL}}/containers/:container-id/metatype_relationship_pairs/:pair-id",
+									"host": [
+										"{{baseURL}}"
+									],
+									"path": [
+										"containers",
+										":container-id",
+										"metatype_relationship_pairs",
+										":pair-id"
+									],
+									"variable": [
+										{
+											"key": "container-id",
+											"value": ""
+										},
+										{
+											"key": "pair-id",
+											"value": ""
+										}
+									]
+								}
 							},
 							"response": []
 						},

--- a/src/api/metatype_relationship_pair_routes.ts
+++ b/src/api/metatype_relationship_pair_routes.ts
@@ -12,6 +12,7 @@ export default class MetatypeRelationshipPairRoutes {
         app.post("/containers/:id/metatype_relationship_pairs", ...middleware, authInContainer("write", "ontology"),this.createMetatypeRelationshipPair);
         app.get("/containers/:id/metatype_relationship_pairs/:relationshipPairID", ...middleware,authInContainer("read", "ontology"), this.retrieveMetatypeRelationshipPair);
         app.get("/containers/:id/metatype_relationship_pairs/", ...middleware, authInContainer("read", "ontology"),this.listMetatypeRelationshipPairs);
+        app.put("/containers/:id/metatype_relationship_pairs/:relationshipPairID", ...middleware, authInContainer("write", "ontology"), this.updateMetatypeRelationshipPair);
         app.delete("/containers/:id/metatype_relationship_pairs/:relationshipPairID", ...middleware, authInContainer("write", "ontology"),this.archiveMetatypeRelationshipPair);
     }
 
@@ -66,6 +67,10 @@ export default class MetatypeRelationshipPairRoutes {
             filter = filter.and().metatypeID("eq", req.query.metatypeID)
         }
 
+        if(req.query.archived as string !== "true") {
+            filter = filter.and().archived("eq", false)
+        }
+
         // @ts-ignore
         filter.all(+req.query.limit, +req.query.offset)
             .then((result) => {
@@ -79,6 +84,18 @@ export default class MetatypeRelationshipPairRoutes {
                 res.status(404).send(err)
             })
             .finally(() => next())
+    }
+
+    private static updateMetatypeRelationshipPair(req: Request, res: Response, next: NextFunction) {
+        storage.Update(req.params.relationshipPairID, req.body)
+            .then((updated) => {
+                if (updated.isError && updated.error) {
+                    res.status(updated.error.errorCode).json(updated);
+                    return
+                }
+                res.status(200).json(updated)
+            })
+            .catch((updated) => res.status(500).send(updated))
     }
 
 

--- a/src/api/metatype_routes.ts
+++ b/src/api/metatype_routes.ts
@@ -55,6 +55,10 @@ export default class MetatypeRoutes {
                 filter = filter.and().name("like", `%${req.query.name}%`)
             }
 
+            if(req.query.archived as string !== "true") {
+                filter = filter.and().archived("eq", false)
+            }
+
             // @ts-ignore
             filter.all(+req.query.limit, +req.query.offset)
                 .then((result) => {

--- a/src/data_storage/metatype_filter.ts
+++ b/src/data_storage/metatype_filter.ts
@@ -28,6 +28,11 @@ export default class MetatypeFilter extends Filter {
         return this
     }
 
+    archived(operator: string, value: any) {
+        super.query("archived", operator, value)
+        return this
+    }
+
     all(limit?: number, offset?:number): Promise<Result<MetatypeT[]>> {
         return super.findAll<MetatypeT>(limit, offset)
     }

--- a/src/data_storage/metatype_relationship_pair_filter.ts
+++ b/src/data_storage/metatype_relationship_pair_filter.ts
@@ -63,6 +63,11 @@ export default class MetatypeRelationshipPairFilter extends Filter {
         return this
     }
 
+    archived(operator: string, value: any) {
+        super.query("metatype_relationship_pairs.archived", operator, value)
+        return this
+    }
+
     all(limit?: number, offset?:number): Promise<Result<MetatypeRelationshipPairT[]>> {
         return super.findAll<MetatypeRelationshipPairT>(limit, offset)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds a route for updating metatype relationship pairs. Additionally adds "archived" filters for metatypes and metatype relationships pairs, making it default behavior that archived entries will not be shown.

## Description
<!--- Describe your changes in detail -->
Postman documentation has been updated accordingly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
All tests pass

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
