### PR TITLE
removed imports holding on to data

### DIFF
--- a/migrations/025_imports.sql
+++ b/migrations/025_imports.sql
@@ -1,0 +1,5 @@
+DROP TRIGGER IF EXISTS unpack_import on imports;
+DROP FUNCTION IF EXISTS unpack_import_row;
+
+ALTER TABLE imports DROP COLUMN data_json;
+ALTER TABLE imports DROP COLUMN data_csv;

--- a/src/api/data_source_routes.ts
+++ b/src/api/data_source_routes.ts
@@ -512,7 +512,7 @@ export default class DataSourceRoutes {
 
                 // create an "import" with a single object, the metadata and file information
                 // the user will then handle the mapping of this via the normal type mapping channels
-                ImportStorage.Instance.InitiateJSONImportAndUnpack(req.params.sourceID, user.id!, 'file upload', metadata)
+                ManualJsonImport(user, req.params.sourceID, metadata)
                     .then((result) => {
                         if (result.isError && result.error) {
                             res.status(result.error.errorCode).json(result);

--- a/src/api_handlers/data_source.ts
+++ b/src/api_handlers/data_source.ts
@@ -16,6 +16,7 @@ import {FileT} from "../types/fileT";
 import FileStorageProvider, {FileUploadResponse} from "../file_storage/file_storage";
 import FileStorage from "../data_storage/file_storage";
 import Logger from "../logger";
+import DataStagingStorage from "../data_storage/import/data_staging_storage";
 
 
 
@@ -61,13 +62,22 @@ export async function NewDataSource(user:UserT, containerID:string, input: any):
     })
 }
 
-export async function ManualJsonImport(user:UserT, dataSourceID: string, payload:any): Promise<Result<boolean>> {
+// This import will create and insert data given the correct information and a payload of JSON objects.
+export async function ManualJsonImport(user:UserT, dataSourceID: string, payload:any): Promise<Result<string>> {
     const dataSource = await DataSourceStorage.Instance.Retrieve(dataSourceID)
     if(dataSource.isError) return new Promise(resolve => resolve(Result.Pass(dataSource)))
 
     if(dataSource.value.adapter_type !== "manual") return new Promise(resolve => resolve(Result.Failure('cannot run manual import for non-manual data source')))
+    if(!Array.isArray(payload)) return new Promise(resolve => resolve(Result.Failure("payload must be an array of JSON objects")))
 
-    return ImportStorage.Instance.InitiateJSONImportAndUnpack(dataSourceID, user.id!, "test", payload)
+    const newImport = await ImportStorage.Instance.InitiateImport(dataSourceID, user.id!, "test")
+
+    for(const data of payload) {
+        const inserted = await DataStagingStorage.Instance.Create(dataSourceID, newImport.value, data)
+        if(inserted.isError) Logger.error(`unable to insert data for import ${inserted.error}`)
+    }
+
+    return new Promise(resolve => resolve(newImport))
 }
 
 // Each data source's configuration is different, this allows us to both set that configuration and perform

--- a/src/data_storage/import/import_storage.ts
+++ b/src/data_storage/import/import_storage.ts
@@ -17,37 +17,13 @@ export default class ImportStorage extends PostgresStorage {
     }
 
 
-    public InitiateJSONImportAndUnpack(dataSourceID: string, userID:string, reference: string, payload: any): Promise<Result<boolean>> {
+    public async InitiateImport(dataSourceID: string, userID:string, reference: string): Promise<Result<string>> {
         const id = uuid.v4();
 
-        // the payload MUST BE AN ARRAY OF OBJECTS, unfortunately the way Typescript's type system works I cannot
-        // easily enforce your payload's type to match the required type by the postgres node driver and functionality
-        const input = (t.array(t.unknown).is(payload)) ? payload : [payload];
-
-        return super.runAsTransaction(
-            ImportStorage.initiateImportJSONStatement(id, dataSourceID,userID, reference, input), ImportStorage.unpackJsonStatement(id)
-        )
-    }
-
-    public async InitiateJSONImport(dataSourceID: string, userID:string, reference: string, payload: any): Promise<Result<string>> {
-        const id = uuid.v4();
-
-        const initiated = await super.runAsTransaction(ImportStorage.initiateImportJSONStatement(id, dataSourceID,userID, reference, payload))
+        const initiated = await super.runAsTransaction(ImportStorage.initiateImportStatement(id, dataSourceID,userID, reference))
         if(initiated.isError) {return new Promise(resolve => resolve(Result.Pass(initiated)))}
 
         return new Promise(resolve => resolve(Result.Success(id)))
-    }
-
-    public AppendToJSONImport(importID: string, payload: any): Promise<Result<boolean>> {
-        return super.runAsTransaction(ImportStorage.appendToJSONImportStatement(importID, payload))
-    }
-
-    public UnpackJSONImport(importID: string): Promise<Result<boolean>> {
-        return super.runAsTransaction(ImportStorage.unpackJsonStatement(importID))
-    }
-
-    public InitiateCSVImport(dataSourceID: string, userID:string, reference:string, payload: any): Promise<Result<boolean>> {
-        return super.runAsTransaction(ImportStorage.initiateImportCSVStatement(dataSourceID,userID, reference, payload))
     }
 
     public Retrieve(id: string): Promise<Result<ImportT>> {
@@ -82,31 +58,10 @@ export default class ImportStorage extends PostgresStorage {
         }
     }
 
-    private static initiateImportJSONStatement(id: string, dataSourceID: string, userID:string, reference:string,  payload:any): QueryConfig {
+    private static initiateImportStatement(id: string, dataSourceID: string, userID:string, reference:string): QueryConfig {
         return {
-            text: `INSERT INTO imports(id,data_source_id,data_json,created_by,modified_by, reference) VALUES($1,$2,$3,$4,$5,$6)`,
-            values: [id,dataSourceID,JSON.stringify(payload), userID, userID, reference]
-        }
-    }
-
-    private static appendToJSONImportStatement(importID: string, payload:any): QueryConfig {
-        return {
-            text: `UPDATE imports SET data_json = data_json || $2::jsonb WHERE id = $1`,
-            values: [importID, JSON.stringify(payload)]
-        }
-    }
-
-    private static initiateImportCSVStatement(dataSourceID: string, userID:string, reference:string, payload:any): QueryConfig {
-        return {
-            text: `INSERT INTO imports(id,data_source_id,data_csv,created_by,modified_by) VALUES($1,$2,$3,$4,$5,$6)`,
-            values: [uuid.v4(),dataSourceID,payload, userID, userID, reference]
-        }
-    }
-
-    private static unpackJsonStatement(importID: string): QueryConfig {
-        return {
-            text: `SELECT "unpack_import_row"($1);`,
-            values: [importID]
+            text: `INSERT INTO imports(id,data_source_id,created_by,modified_by, reference) VALUES($1,$2,$3,$4,$5)`,
+            values: [id,dataSourceID,userID, userID, reference]
         }
     }
 

--- a/src/test/data_processing/import.spec.ts
+++ b/src/test/data_processing/import.spec.ts
@@ -28,56 +28,6 @@ describe('An Import Adapter Import', async() => {
         return Promise.resolve()
     });
 
-    it('can be initiated and unpacked', async()=> {
-        let storage = DataSourceStorage.Instance;
-        let logStorage = ImportStorage.Instance;
-
-        let exp = await storage.Create(containerID, "test suite",
-            {
-                name: "Test Data Source",
-                active:false,
-                adapter_type:"http",
-                config: {}});
-
-        expect(exp.isError).false;
-        expect(exp.value).not.empty;
-
-        let log = await logStorage.InitiateJSONImportAndUnpack(exp.value.id!, "test suite", "test", payload);
-        expect(log.isError).false;
-
-        return storage.PermanentlyDelete(exp.value.id!)
-    });
-
-    it('can be initiated, appended to, and unpacked', async()=> {
-        let storage = DataSourceStorage.Instance;
-        let logStorage = ImportStorage.Instance;
-
-        let exp = await storage.Create(containerID, "test suite",
-            {
-                name: "Test Data Source",
-                active:false,
-                adapter_type:"http",
-                config: {}});
-
-        expect(exp.isError).false;
-        expect(exp.value).not.empty;
-
-        let log = await logStorage.InitiateJSONImport(exp.value.id!, "test suite", "test", payload);
-        expect(log.isError).false;
-
-
-        let logs = await logStorage.ListReady(exp.value.id!, 0, 100);
-        expect(logs.isError).false;
-        expect(logs.value).not.empty;
-
-        for(const l of logs.value) {
-           let appended = await logStorage.AppendToJSONImport(l.id, [{"appended": "appended"}])
-            expect(appended.isError).false
-        }
-
-        return storage.PermanentlyDelete(exp.value.id!)
-    });
-
     it('can be listed', async()=> {
         let storage = DataSourceStorage.Instance;
         let logStorage = ImportStorage.Instance;
@@ -92,7 +42,7 @@ describe('An Import Adapter Import', async() => {
         expect(exp.isError).false;
         expect(exp.value).not.empty;
 
-        let log = await logStorage.InitiateJSONImportAndUnpack(exp.value.id!, "test suite", "test", payload);
+        let log = await logStorage.InitiateImport(exp.value.id!, "test suite", "test");
         expect(log.isError).false;
 
         let logs = await logStorage.List(exp.value.id!, 0, 100);
@@ -116,7 +66,7 @@ describe('An Import Adapter Import', async() => {
         expect(exp.isError).false;
         expect(exp.value).not.empty;
 
-        let log = await logStorage.InitiateJSONImportAndUnpack(exp.value.id!, "test suite", "test", payload);
+        let log = await logStorage.InitiateImport(exp.value.id!, "test suite", "test");
         expect(log.isError).false;
 
         let logs = await logStorage.ListReady(exp.value.id!, 0, 100);
@@ -149,7 +99,7 @@ describe('An Import Adapter Import', async() => {
         expect(exp.isError).false;
         expect(exp.value).not.empty;
 
-        let log = await logStorage.InitiateJSONImportAndUnpack(exp.value.id!, "test suite", "test", payload);
+        let log = await logStorage.InitiateImport(exp.value.id!, "test suite", "test");
         expect(log.isError).false;
 
         let logs = await logStorage.ListReady(exp.value.id!, 0, 100);
@@ -182,7 +132,7 @@ describe('An Import Adapter Import', async() => {
         expect(exp.isError).false;
         expect(exp.value).not.empty;
 
-        let log = await logStorage.InitiateJSONImportAndUnpack(exp.value.id!, "test suite", "test", payload);
+        let log = await logStorage.InitiateImport(exp.value.id!, "test suite", "test");
         expect(log.isError).false;
 
         let logs = await logStorage.ListReady(exp.value.id!, 0, 100);

--- a/src/test/data_processing/processing.spec.ts
+++ b/src/test/data_processing/processing.spec.ts
@@ -121,9 +121,10 @@ describe('Data Processing Can', async() => {
 
         // First create the import and load the test data as an import, we create
         // a manual data storage object in this instance, though it doesn't really matter
-        let imports = await importStorage.InitiateJSONImportAndUnpack(dataSourceID, "test suite", "test", [test_raw_payload])
+        let imports = await importStorage.InitiateImport(dataSourceID, "test suite", "test")
         expect(imports.isError).false
 
+        await DataStagingStorage.Instance.Create(dataSourceID, imports.value, test_raw_payload)
         // Next, create the mapping and attempt to use mapping to query matching data
         // that should exist in data_staging. Has the added bonus of testing that
         // trigger for taking json data from imports and parsing to data_staging

--- a/src/test/data_processing/type_mapping.spec.ts
+++ b/src/test/data_processing/type_mapping.spec.ts
@@ -672,9 +672,10 @@ describe('We can use a Data Type Mapping To', async() => {
 
         // First create the import and load the test data as an import, we create
         // a manual data storage object in this instance, though it doesn't really matter
-        let imports = await importStorage.InitiateJSONImportAndUnpack(dataSourceID, "test suite", "test", [test_raw_payload])
+        let imports = await importStorage.InitiateImport(dataSourceID, "test suite", "test")
         expect(imports.isError).false
 
+        await DataStagingStorage.Instance.Create(dataSourceID, imports.value, test_raw_payload)
         // Next, create the mapping and attempt to use mapping to query matching data
         // that should exist in data_staging. Has the added bonus of testing that
         // trigger for taking json data from imports and parsing to data_staging
@@ -730,9 +731,10 @@ describe('We can use a Data Type Mapping To', async() => {
 
         // First create the import and load the test data as an import, we create
         // a manual data storage object in this instance, though it doesn't really matter
-        let imports = await importStorage.InitiateJSONImportAndUnpack(dataSourceID, "test suite",  "test", [test_raw_payload2])
+        let imports = await importStorage.InitiateImport(dataSourceID, "test suite",  "test")
         expect(imports.isError).false
 
+        await DataStagingStorage.Instance.Create(dataSourceID, imports.value, test_raw_payload2)
         // Next, create the mapping and attempt to use mapping to query matching data
         // that should exist in data_staging. Has the added bonus of testing that
         // trigger for taking json data from imports and parsing to data_staging
@@ -787,9 +789,10 @@ describe('We can use a Data Type Mapping To', async() => {
 
         // First create the import and load the test data as an import, we create
         // a manual data storage object in this instance, though it doesn't really matter
-        let imports = await importStorage.InitiateJSONImportAndUnpack(dataSourceID, "test suite", "test", [test_raw_payload])
+        let imports = await importStorage.InitiateImport(dataSourceID, "test suite", "test")
         expect(imports.isError).false
 
+        await DataStagingStorage.Instance.Create(dataSourceID, imports.value, test_raw_payload)
         // Next, create the mapping and attempt to use mapping to query matching data
         // that should exist in data_staging. Has the added bonus of testing that
         // trigger for taking json data from imports and parsing to data_staging


### PR DESCRIPTION
## Description
Closes #16 and Closes #48 

I modified the `data_staging` table to remove the `data_json` and `data_csv` columns. This was being used as a staging area for data before it was split into individual `data_staging` records. Instead of doing that, we now split the data into `data_staging` rows on data ingestion. This lifts the 4gb max row size problem we faced with data and opens up the way to accept data of different types more easily than modifying and storing interim data in `imports`

## How Has This Been Tested?
Tested through the UI and the test suite

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
