### PR TITLE
Name query param no longer required

### DIFF
--- a/src/api/metatype_routes.ts
+++ b/src/api/metatype_routes.ts
@@ -51,7 +51,7 @@ export default class MetatypeRoutes {
             let filter = new MetatypeFilter()
             filter = filter.where().containerID("eq", req.params.id)
 
-            if(req.query.name as string !== "") {
+            if(typeof req.query.name !== "undefined" && req.query.name as string !== "") {
                 filter = filter.and().name("like", `%${req.query.name}%`)
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Name query param is no longer required and now acts as an optional parameter. This change is required to get list metatypes functionality working correctly in the admin UI and elsewhere.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
