### PR TITLE
Fix/naming scheme

### DIFF
--- a/src/api/container_routes.ts
+++ b/src/api/container_routes.ts
@@ -13,8 +13,8 @@ const exportStorage = ExportStorage.Instance;
 // as it was not large enough to pull into its own functionality.
 export default class ContainerRoutes {
     public static mount(app: Application, middleware:any[]) {
-        app.post("/containers", ...middleware, authRequest("write", "containers"), this.createContainer);
-        app.put("/containers",...middleware,authRequest("write", "containers"), this.batchUpdate);
+        app.post("/containers", ...middleware,this.createContainer);
+        app.put("/containers",...middleware,authRequest("write", "containers"),this.batchUpdate);
         app.get("/containers/:id",...middleware, authRequest("read", "containers"),this.retrieveContainer);
 
         // we don't auth this request as the actual handler will only ever show containers

--- a/src/api_handlers/container.ts
+++ b/src/api_handlers/container.ts
@@ -4,6 +4,7 @@ import {ContainersT, ContainerT} from "../types/containerT";
 import ContainerStorage from "../data_storage/container_storage";
 import {Authorization} from "../user_management/authorization/authorization"
 import Logger from "../logger";
+import {AssignUserRole} from "../user_management/users";
 
 // Container creation must also handle creation of policies regarding the management of said container
 // because of this, creation is pulled out into its own function vs. simply connecting the storage
@@ -70,6 +71,20 @@ export async function CreateContainer(user:UserT | any, input:any): Promise<Resu
         const dataAdminWrite = await e.addPolicy('admin', container.id!, 'data', 'read');
         if(!dataAdminWrite) Logger.error(`unable to add editor policy to new container`);
     }
+
+    // assign the creating user Admin privileges for each container created
+    for(const container of containers.value) {
+       const result = await AssignUserRole(user, {
+            user_id: user.id,
+            container_id: container.id,
+            role_name: "admin"
+        })
+
+       if(result.isError) {
+            Logger.error(`unable to assign role to user for newly created container ${result.error}`)
+        }
+    }
+
 
     return Promise.resolve(containers)
 }

--- a/src/data_query/resolvers.ts
+++ b/src/data_query/resolvers.ts
@@ -371,8 +371,8 @@ async function EdgeResolver(nodeID: string, direction: "incoming" | "outgoing"):
                 properties: PropertyResolver(edge.properties),
                 raw_properties: JSON.stringify(edge.properties),
                 relationship: MetatypeRelationshipByPairResolver(edge.relationship_pair_id),
-                destination: NodeResolverByID(edge.destination_node_id!, edge.container_id!),
-                origin: NodeResolverByID(edge.origin_node_id!, edge.container_id!),
+                destination_node: NodeResolverByID(edge.destination_node_id!, edge.container_id!),
+                origin_node: NodeResolverByID(edge.origin_node_id!, edge.container_id!),
                 created_at: createdAt,
                 modified_at: modifiedAt
             })

--- a/src/data_query/schema.ts
+++ b/src/data_query/schema.ts
@@ -109,8 +109,8 @@ input PropertyFilter {
 
   relationship: MetatypeRelationship
 
-  origin: Node
-  destination: Node
+  origin_node: Node
+  destination_node: Node
   }
 
   type File {

--- a/src/data_query/types.ts
+++ b/src/data_query/types.ts
@@ -97,8 +97,8 @@ export type EdgeQL = {
     modified_at: string
 
     relationship: Promise<MetatypeRelationshipQL>
-    origin: Promise<NodeQL>
-    destination: Promise<NodeQL>
+    origin_node: Promise<NodeQL>
+    destination_node: Promise<NodeQL>
     properties: PropertyQL[]
     raw_properties: string
 }

--- a/src/data_storage/graph/edge_filter.ts
+++ b/src/data_storage/graph/edge_filter.ts
@@ -9,6 +9,8 @@ export default class EdgeFilter extends Filter {
 
         // we must include the joins for the relationship and relationship pair table
         // in order to be able to filter by relationship name
+        this._rawQuery = []
+        this._rawQuery.push(`SELECT edges.* FROM ${EdgeStorage.tableName}`)
         this._rawQuery.push(`LEFT JOIN metatype_relationship_pairs ON edges.relationship_pair_id = metatype_relationship_pairs.id`)
         this._rawQuery.push(`LEFT JOIN metatype_relationships ON metatype_relationship_pairs.relationship_id = metatype_relationships.id`)
     }
@@ -71,6 +73,9 @@ export default class EdgeFilter extends Filter {
     async all(limit?: number, offset?:number): Promise<Result<EdgeT[]>> {
         const results = await super.findAll<EdgeT>(limit, offset);
 
+        // reset the query
+        this._rawQuery = []
+        this._rawQuery.push(`SELECT edges.* FROM ${EdgeStorage.tableName}`)
         this._rawQuery.push(`LEFT JOIN metatype_relationship_pairs ON edges.relationship_pair_id = metatype_relationship_pairs.id`)
         this._rawQuery.push(`LEFT JOIN metatype_relationships ON metatype_relationship_pairs.relationship_id = metatype_relationships.id`)
 


### PR DESCRIPTION
## Description
Quick bugfixes to the naming scheme and the Edges resolver. Corrected an issue in which all the edges were returning with a duplicated ID

Also removed permissions needed to create a new container. When a user creates a new container they are automatically made admins of said container.
## Motivation and Context
Fixes a bug needed for graph querying

## How Has This Been Tested?
Test suite

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
