### PR TITLE
created md5 hash on fileupload

### DIFF
--- a/migrations/026_file_md5hash.sql
+++ b/migrations/026_file_md5hash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE files ADD COLUMN md5hash text;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2151,6 +2151,14 @@
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
+    "digest-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/digest-stream/-/digest-stream-2.0.0.tgz",
+      "integrity": "sha1-8eCa7X0Snyg/lAYivFy6NT0YfIk=",
+      "requires": {
+        "pass-stream": "^1.0.0"
+      }
+    },
     "dont-sniff-mimetype": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.1.0.tgz",
@@ -4928,6 +4936,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "pass-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pass-stream/-/pass-stream-1.0.0.tgz",
+      "integrity": "sha1-coUK1rIP96JySngPUOJQYgC2HoI="
     },
     "passport": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "csvtojson": "^2.0.10",
+    "digest-stream": "^2.0.0",
     "dot-prop": "^5.3.0",
     "express": "^4.17.1",
     "express-fileupload": "^1.2.0",

--- a/src/api_handlers/data_source.ts
+++ b/src/api_handlers/data_source.ts
@@ -138,10 +138,11 @@ export async function DataSourceUploadFile(containerID: string, dataSourceID: st
     const file = {
         file_name: filename,
         file_size: result.value.size,
+        md5hash: result.value.md5hash,
         adapter_file_path: result.value.filepath,
         adapter: provider.name(),
         metadata: result.value.metadata,
-    }
+    } as FileT
 
     return FileStorage.Instance.Create(userID, containerID, dataSourceID, file)
 }

--- a/src/data_storage/file_storage.ts
+++ b/src/data_storage/file_storage.ts
@@ -121,8 +121,8 @@ export default class FileStorage extends PostgresStorage{
     // queries more easily.
     private static createStatement(file: FileT): QueryConfig[] {
         return [{
-           text:`INSERT INTO files(id,container_id,file_name,file_size,adapter_file_path,adapter,metadata,data_source_id,created_by,modified_by) VALUES($1, $2, $3, $4,$5,$6,$7,$8,$9,$10)`,
-           values: [file.id,file.container_id,file.file_name,file.file_size,file.adapter_file_path,file.adapter,JSON.stringify(file.metadata),file.data_source_id,file.created_by,file.modified_by]
+           text:`INSERT INTO files(id,container_id,file_name,file_size,adapter_file_path,adapter,metadata,data_source_id,created_by,modified_by,md5hash) VALUES($1, $2, $3, $4,$5,$6,$7,$8,$9,$10,$11)`,
+           values: [file.id,file.container_id,file.file_name,file.file_size,file.adapter_file_path,file.adapter,JSON.stringify(file.metadata),file.data_source_id,file.created_by,file.modified_by, file.md5hash]
             }
           ]
     }

--- a/src/file_storage/file_storage.ts
+++ b/src/file_storage/file_storage.ts
@@ -16,6 +16,7 @@ export type FileUploadResponse = {
     filename: string
     filepath: string
     size: number // size in KB
+    md5hash: string // hex encoded md5 hash
     metadata: {[key:string]: any} // adapter specific metadata if needed
     adapter_name: string
 }

--- a/src/file_storage/mock_impl.ts
+++ b/src/file_storage/mock_impl.ts
@@ -47,6 +47,7 @@ export default class MockFileStorageImpl implements FileStorage {
                                 filepath: uploadPath,
                                 filename: fileName,
                                 size: 0,
+                                md5hash: "",
                                 metadata: {},
                                 adapter_name: 'mock'
                             }));
@@ -68,6 +69,7 @@ export default class MockFileStorageImpl implements FileStorage {
                             filepath: uploadPath,
                             filename: fileName,
                             size: 0,
+                            md5hash: "",
                             metadata: {},
                             adapter_name: 'mock'
                         }));

--- a/src/types/fileT.ts
+++ b/src/types/fileT.ts
@@ -4,6 +4,7 @@ import {recordMetaT} from "./recordMetaT";
 const fileRequired = t.type({
     file_name: t.string,
     file_size: t.number,
+    md5hash: t.string,
     adapter_file_path: t.string,
     adapter: t.keyof({
         'aws_s3': null,


### PR DESCRIPTION
## Description
Closes #61 

I implemented MD5 hash storage for uploaded files. This required changes to the Azure and Filesystem storage methods as well as including a new npm package - digest-streams.

## Motivation and Context
MD5 hash on files will allow end users to validate that they've successfully stored and downloaded files from Deep Lynx.

## How Has This Been Tested?
Test suite and used Azure Blob.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
