### PR TITLE
Cascade all dependencies of container on permanent delete

### DIFF
--- a/api_documentation/Core.postman_collection.json
+++ b/api_documentation/Core.postman_collection.json
@@ -170,6 +170,12 @@
 								"containers",
 								":container-id"
 							],
+							"query": [
+								{
+									"key": "permanent",
+									"value": "true"
+								}
+							],
 							"variable": [
 								{
 									"id": "ae6760f8-e98b-4c8c-b9fe-4349e0d3e1e0",
@@ -179,7 +185,7 @@
 								}
 							]
 						},
-						"description": "Archives a Container. This is preferred over deletion as deletion has a cascading effect on the deleted type's keys, relationships, and relationship keys. When in doubt, archive over delete. We'd rather have tombstones than cremating the type."
+						"description": "Archive or delete a Container. Accepts a single query parameter - permanent. If this query parameter is provided (with any value), the container will be permanently deleted, forcing a cascade to all dependent objects in the database. Generally we prefer to archive rather than delete."
 					},
 					"response": []
 				}

--- a/api_documentation/Core.swagger_collection.json
+++ b/api_documentation/Core.swagger_collection.json
@@ -210,7 +210,7 @@
         }
       },
       "delete": {
-        "description": "Archives a Container. This is preferred over deletion as deletion has a cascading effect on the deleted type's keys, relationships, and relationship keys. When in doubt, archive over delete. We'd rather have tombstones than cremating the type.",
+        "description": "Archive or delete a Container. Accepts a single query parameter - permanent. If this query parameter is provided (with any value), the container will be permanently deleted, forcing a cascade to all dependent objects in the database. Generally we prefer to archive rather than delete.",
         "summary": "Archive",
         "tags": [
           "Containers"
@@ -227,6 +227,14 @@
             "required": true,
             "type": "string",
             "description": ""
+          },
+          {
+            "name": "permanent",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "format": "string",
+            "description": "If supplied, the container will be permanently deleted"
           }
         ],
         "responses": {

--- a/migrations/028_container_delete.sql
+++ b/migrations/028_container_delete.sql
@@ -1,0 +1,30 @@
+ALTER TABLE metatypes 
+DROP CONSTRAINT metatypes_container_id_fkey,
+ADD CONSTRAINT metatypes_container_id_fkey
+   FOREIGN KEY (container_id)
+   REFERENCES containers(id)
+   ON DELETE CASCADE;
+ALTER TABLE metatype_relationship_pairs 
+DROP CONSTRAINT metatype_relationship_pairs_container_id_fkey,
+ADD CONSTRAINT metatype_relationship_pairs_container_id_fkey
+   FOREIGN KEY (container_id)
+   REFERENCES containers(id)
+   ON DELETE CASCADE;
+ALTER TABLE exports 
+DROP CONSTRAINT exports_container_id_fkey,
+ADD CONSTRAINT exports_container_id_fkey
+   FOREIGN KEY (container_id)
+   REFERENCES containers(id)
+   ON DELETE CASCADE;
+ALTER TABLE data_sources 
+DROP CONSTRAINT data_sources_container_id_fkey,
+ADD CONSTRAINT data_sources_container_id_fkey
+   FOREIGN KEY (container_id)
+   REFERENCES containers(id)
+   ON DELETE CASCADE;
+ALTER TABLE files 
+DROP CONSTRAINT files_container_id_fkey,
+ADD CONSTRAINT files_container_id_fkey
+   FOREIGN KEY (container_id)
+   REFERENCES containers(id)
+   ON DELETE CASCADE;

--- a/src/api/container_routes.ts
+++ b/src/api/container_routes.ts
@@ -106,7 +106,19 @@ export default class ContainerRoutes {
     private static archiveContainer(req: Request, res: Response, next: NextFunction) {
         const user = req.user as UserT;
 
-        storage.Archive(req.params.id, user.id!)
+        if(req.query.permanent) {
+            storage.PermanentlyDelete(req.params.id)
+            .then((result) => {
+                if (result.isError && result.error) {
+                    res.status(result.error.errorCode).json(result);
+                    return
+                }
+                res.sendStatus(200)
+            })
+            .catch((err) => res.status(500).send(err))
+            .finally(() => next())
+        } else {
+            storage.Archive(req.params.id, user.id!)
             .then((result) => {
                 if (result.isError && result.error) {
                     res.status(result.error.errorCode).json(result);
@@ -117,6 +129,7 @@ export default class ContainerRoutes {
             .catch((err) => res.status(500).send(err))
             .finally(() => next())
         }
+    }
 
     private static exportDataFromContainer(req: Request, res: Response, next: NextFunction) {
         NewDataExport(req.user as UserT,req.params.id, req.body)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Enable full cascade of dependent data on container delete. Add a query parameter to the container delete route to enable permanent delete through an API call.

## Description
<!--- Describe your changes in detail -->
This change adds another database migration file to alter several foreign keys on Container(id) so that they will cascade on deletion of a container. A query parameter is also added to the delete container API to handle permanent deletes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested through Postman

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Postman and swagger docs manually updated
