### PR TITLE
corrected nested array fetching, poll interval on data source

### DIFF
--- a/web_ui/src/components/newDataSourceDialog.vue
+++ b/web_ui/src/components/newDataSourceDialog.vue
@@ -77,6 +77,12 @@
                                         ></v-text-field>
 
                                     </div>
+                                  <v-text-field
+                                      v-model="newDataSource.config.poll_interval"
+                                      label="Poll Interval (in seconds)"
+                                      type="number"
+                                      required
+                                  ></v-text-field>
                                 </div>
                                 <v-checkbox
                                         v-model="newDataSource.active"

--- a/web_ui/src/utilities.ts
+++ b/web_ui/src/utilities.ts
@@ -1,0 +1,20 @@
+// this function is fully tested inside the main Deep Lynx repository. I've only
+// pulled it out into this file for ease of use when importing the function from
+// inside the UI.
+export function getNestedValue(key: string, payload: any, index?: number[]): any {
+    const copiedIndex = (index) ? [...index] : undefined
+    if(key.split(".").length > 1) {
+        const keys = key.split(".")
+        const parent = keys.shift()
+
+        if(Array.isArray(payload)) {
+            const currentIndex = copiedIndex?.shift()
+
+            return getNestedValue(keys.join("."), payload[currentIndex!], copiedIndex)
+        }
+
+        return getNestedValue(keys.join("."), payload[parent!], copiedIndex)
+    }
+
+    return payload[key]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added the ability to set poll interval on HTTP poller Data Source type.
Modified the Transformation to allow nested arrays when selecting root arrays and individual keys.

## Motivation and Context
This was needed so that deeply nested payloads could be transformed correctly. The backend portion for handling the nesting of arrays has already been created.

## How Has This Been Tested?
Test suite ran, multiple UI tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
