### PR TITLE
stub cache implementation

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -5,7 +5,7 @@ ROOT_ADDRESS=http://localhost:8090
 # there are various processes that look for other compiled typescript files
 PROJECT_DIR=./dist
 
-# valid options are blank (defaults to memory), memory, or redis
+# valid options are blank for no caching, memory, or redis
 CACHE_PROVIDER=memory
 # default time in seconds
 CACHE_DEFAULT_TTL=21600

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,7 +98,7 @@ export class Config {
     // here in the config file.
     this._is_windows = process.platform === 'win32'
 
-    this._cache_provider = process.env.CACHE_PROVIDER || "memory"
+    this._cache_provider = process.env.CACHE_PROVIDER || ""
     this._cache_default_ttl = (process.env.CACHE_DEFAULT_TTL) ? parseInt(process.env.CACHE_DEFAULT_TTL!, 10): 21600
     // default to a local, non-password-protected instance of redis
     this._cache_redis_connection_string = process.env.CACHE_REDIS_CONNECTION_STRING || "//localhost:6379"

--- a/src/services/cache/cache.ts
+++ b/src/services/cache/cache.ts
@@ -30,7 +30,7 @@ class Cache {
             }
 
             default: {
-                this.cache = new MemoryCacheImpl()
+                this.cache = new StubCacheImpl()
                 break;
             }
         }
@@ -41,6 +41,29 @@ export interface CacheInterface {
     set(key: string, val: any, ttl?: number): Promise<boolean>
     del(key: string): Promise<boolean>
     get<T>(key: string): Promise<T | undefined>
+}
+
+// stub is used when no cache is selected. This should be rare as DL should at
+// least use memory caching.
+export class StubCacheImpl implements CacheInterface {
+    private _cache: any
+    get<T>(key: string): Promise<T | undefined> {
+        return new Promise(resolve => resolve(undefined))
+    }
+
+    // default to successful so that we don't throw up errors everywhere
+    set(key: string, val: any, ttl?: number): Promise<boolean> {
+        return new Promise(resolve => resolve(true))
+    }
+
+    // default to successful so we don't throw up errors everywhere
+    del(key: string): Promise<boolean> {
+        return new Promise(resolve => resolve(true))
+    }
+
+    constructor() {
+        this._cache = new NodeCache()
+    }
 }
 
 export class MemoryCacheImpl implements CacheInterface {

--- a/src/services/cache/cache.ts
+++ b/src/services/cache/cache.ts
@@ -46,7 +46,6 @@ export interface CacheInterface {
 // stub is used when no cache is selected. This should be rare as DL should at
 // least use memory caching.
 export class StubCacheImpl implements CacheInterface {
-    private _cache: any
     get<T>(key: string): Promise<T | undefined> {
         return new Promise(resolve => resolve(undefined))
     }
@@ -59,10 +58,6 @@ export class StubCacheImpl implements CacheInterface {
     // default to successful so we don't throw up errors everywhere
     del(key: string): Promise<boolean> {
         return new Promise(resolve => resolve(true))
-    }
-
-    constructor() {
-        this._cache = new NodeCache()
     }
 }
 

--- a/src/test/.env-sample
+++ b/src/test/.env-sample
@@ -19,7 +19,7 @@ GREMLIN_PLUGIN_GRAPHSON_V1=true
 CORE_DB_CONNECTION_STRING=
 
 
-# valid options are blank (defaults to memory), memory, or redis
+# valid options are blank for no caching, memory, or redis
 CACHE_PROVIDER=memory
 # default time in seconds
 CACHE_DEFAULT_TTL=21600

--- a/src/test/cache/cache.spec.ts
+++ b/src/test/cache/cache.spec.ts
@@ -1,6 +1,46 @@
 /* tslint:disable */
 import {expect} from 'chai'
-import {MemoryCacheImpl, RedisCacheImpl} from "../../services/cache/cache"
+import {MemoryCacheImpl, RedisCacheImpl, StubCacheImpl} from "../../services/cache/cache"
+
+
+describe('Stub Cache implementation can', async() => {
+    it('save an item to the cache', async()=> {
+        const cache = new StubCacheImpl()
+
+        const testObject = {
+            test: "test",
+            number: 1
+        }
+
+        const set = await cache.set("test object", testObject, 1000)
+        expect(set).true
+    });
+
+    it('retrieve an item from the cache', async()=> {
+        const cache = new StubCacheImpl()
+
+        const testObject = {
+            test: "test",
+            number: 1
+        }
+
+        const set = await cache.set("test object", testObject, 1000)
+        expect(set).true
+
+        const retrieved = await cache.get<any>("test object")
+
+        expect(retrieved).undefined
+    });
+
+
+    it('remove an item from the cache', async()=> {
+        const cache = new StubCacheImpl()
+
+        const deleted = await cache.del("test object")
+        expect(deleted).true
+    });
+
+});
 
 describe('Memory Cache implementation can', async() => {
     it('save an item to the cache', async()=> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Created a stub cache implementation that returns positive results for set,del and undefined for get.

## Motivation and Context
In the rare case someone is running clustered DL without Redis caching we needed the ability to turn off in-memory caching so that cache invalidation wouldn't be a problem across the clustered environment. Instead of throwing in a switch at each point the cache is called inside the code, better to just design a stub implementation to take the place for the true cache implementation if caching is not wanted.

## How Has This Been Tested?
Test suite ran.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
