### PR TITLE
added row locking to enable clustering

### DIFF
--- a/src/data_importing/data_source.ts
+++ b/src/data_importing/data_source.ts
@@ -21,7 +21,10 @@ export async function StartDataSourcePolling(): Promise<Result<boolean>> {
         switch(source.adapter_type) {
             case "http": {
                 const httpImporter = await HttpImpl.NewFromDataSourceRecord(source);
-                if(httpImporter.isError) return new Promise(resolve => resolve(Result.Pass(httpImporter)));
+                if(httpImporter.isError) {
+                    Logger.error(`unable to initiate http importer ${httpImporter.error}`)
+                    continue
+                }
 
                 httpImporter.value.Poll()
             }

--- a/src/test/data_processing/processing.spec.ts
+++ b/src/test/data_processing/processing.spec.ts
@@ -252,10 +252,12 @@ describe('A Data Processor', async() => {
         const active = await TypeMappingStorage.Instance.SetActive(typeMappingID)
         expect(active.isError).false
 
+        const dataImport = await ImportStorage.Instance.Retrieve(dataImportID)
+        expect(dataImport.isError).false
 
         const processor = new DataSourceProcessor(dataSource!,graphID)
 
-        let processed = await processor.process(dataImportID)
+        let processed = await processor.process(dataImport.value)
         expect(processed.isError).false
         expect(processed.value).true
 

--- a/src/test/exports/storage.spec.ts
+++ b/src/test/exports/storage.spec.ts
@@ -55,6 +55,21 @@ describe('An Export', async() => {
         return storage.PermanentlyDelete(exp.value.id!)
     });
 
+    it('can be have its status set', async()=> {
+        let storage = ExportStorage.Instance;
+
+        let exp = await storage.Create(containerID, "test suite",
+            {container_id: containerID, adapter:"gremlin", config: {}});
+
+        expect(exp.isError).false;
+        expect(exp.value).not.empty;
+
+        let set = await storage.SetStatus(exp.value.id!, "processing");
+        expect(set.isError).false;
+
+        return storage.PermanentlyDelete(exp.value.id!)
+    });
+
     it('can be listed from storage', async()=> {
         let storage = ExportStorage.Instance;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes #145 
Closes #146 

Modified Import and Gremlin Export storage layers to support locking of individual rows.
Modified the data processing loop to lock and import for processing, and respect that lock throughout.
Modified the data exporting gremlin implementation to support locking of individual data rows prior to export.
Modified data source http poller to lock the previous and created imports to ensure that no other instance of the poller was pulling in identical information.

## Motivation and Context
Deep Lynx needed to be able to ensure that data was not duplicated during export, import, or processing when running in a clustered environment.

## How Has This Been Tested?
New test added, test suite ran and functional.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
