### PR TITLE
Add ontology update page under taxonomy, various minor fixes

### DIFF
--- a/web_ui/src/api/client.ts
+++ b/web_ui/src/api/client.ts
@@ -92,6 +92,38 @@ export class Client {
       })
    }
 
+   async updateContainerFromImport(containerID: string, owlFile: File | null, owlFilePath: string): Promise<string> {
+      const config: {[key: string]: any} = {}
+      config.headers = {"Access-Control-Allow-Origin": "*"}
+
+      if(this.config?.auth_method === "token") {
+         config.headers = {"Authorization": `Bearer ${RetrieveJWT()}`}
+      }
+
+      if(this.config?.auth_method === "basic") {
+         config.auth = {username: this.config.username, password: this.config.password}
+      }
+
+      const formData = new FormData()
+      if(owlFile) {
+         formData.append('file', owlFile)
+      }
+
+      if(owlFilePath !== "") {
+         formData.append('path', owlFilePath)
+      }
+
+      const resp: AxiosResponse = await axios.put(buildURL(this.config?.rootURL!, {path: `containers/import/${containerID}`}), formData, config as AxiosRequestConfig)
+
+      return new Promise((resolve, reject) => {
+         if(resp.status < 200 || resp.status > 299) reject(resp.status)
+
+         if(resp.data.isError) reject(resp.data.error)
+
+         resolve(resp.data.value)
+      })
+   }
+
    deleteContainer(containerID: string): Promise<boolean> {
       return this.delete(`/containers/${containerID}`)
    }

--- a/web_ui/src/pages/Home.vue
+++ b/web_ui/src/pages/Home.vue
@@ -61,6 +61,16 @@
                         </v-list-item-content>
                     </v-list-item>
 
+                    <v-list-item two-line link
+                                 v-if="$auth.Auth('ontology', 'read', containerID)"
+                                 @click="setActiveComponent('ontology-update')"
+                                 :input-value="currentMainComponent === 'OntologyUpdate'">
+                        <v-list-item-content>
+                            <v-list-item-title>{{$t("home.ontologyUpdate")}}</v-list-item-title>
+                            <v-list-item-subtitle>{{$t("home.ontologyUpdateDescription")}}</v-list-item-subtitle>
+                        </v-list-item-content>
+                    </v-list-item>
+
                 </v-list-group>
 
                 <v-list-group :value="false" dense>
@@ -193,6 +203,7 @@
     import Metatypes from "@/views/Metatypes.vue"
     import MetatypeRelationships from "@/views/MetatypeRelationships.vue"
     import MetatypeRelationshipPairs from "@/views/MetatypeRelationshipPairs.vue"
+    import OntologyUpdate from "@/views/OntologyUpdate.vue"
     import TaxonomyImport from "@/views/TaxonomyImport.vue"
     import DataExplorer from "@/views/DataExplorer.vue"
     import DataExport from "@/views/DataExport.vue"
@@ -216,6 +227,7 @@
             Metatypes,
             MetatypeRelationships,
             MetatypeRelationshipPairs,
+            OntologyUpdate,
             TaxonomyImport,
             DataExplorer,
             DataExport,
@@ -268,6 +280,12 @@
                 case "metatype-relationship-pairs": {
                     this.currentMainComponent = "MetatypeRelationshipPairs";
                     this.componentName = this.$t('home.metatypeRelationshipPairs')
+                    break;
+                }
+
+                case "ontology-update": {
+                    this.currentMainComponent = "OntologyUpdate";
+                    this.componentName = this.$t('home.ontologyUpdate')
                     break;
                 }
 

--- a/web_ui/src/translations.ts
+++ b/web_ui/src/translations.ts
@@ -10,6 +10,8 @@ export default {
       metatypeRelationshipsDescription: "Modify Relationships",
       metatypeRelationshipPairs: "Metatype Relationship Pairs",
       metatypeRelationshipPairsDescription: "Modify Metatype Relationship Pairs",
+      ontologyUpdate: "Update Ontology",
+      ontologyUpdateDescription: "Update via Ontology File",
       import: "Import",
       data: "Data",
       dataSources: "Data Sources",
@@ -287,6 +289,9 @@ export default {
       destinationMetatype: "Search Destination Metatype",
       relationship: "Search Relationship",
       pairSuccessfullyCreated: "Successfully Created Metatype Relationship Pair"
+    },
+    ontologyUpdate: {
+      formTitle: "Update Taxonomy via Ontology File",
     },
     dataSources: {
       create: "Create",

--- a/web_ui/src/views/Containers.vue
+++ b/web_ui/src/views/Containers.vue
@@ -15,7 +15,7 @@
                        vertical
                ></v-divider>
                <v-spacer></v-spacer>
-               <new-container-dialog @containerCreated="refreshContainers"></new-container-dialog>
+               <create-container-dialog @containerCreated="refreshContainers"></create-container-dialog>
             </v-toolbar>
 
             <!-- TODO: Set search capability

--- a/web_ui/src/views/MetatypeRelationships.vue
+++ b/web_ui/src/views/MetatypeRelationships.vue
@@ -7,7 +7,6 @@
         :options.sync="options"
         :loading="loading"
         :items-per-page="100"
-        :item-key="id"
         :footer-props="{
           'items-per-page-options': [25, 50, 100]
         }"

--- a/web_ui/src/views/Metatypes.vue
+++ b/web_ui/src/views/Metatypes.vue
@@ -10,7 +10,6 @@
         :footer-props="{
           'items-per-page-options': [25, 50, 100]
         }"
-        :item-key="id"
         class="elevation-1"
     >
 

--- a/web_ui/src/views/OntologyUpdate.vue
+++ b/web_ui/src/views/OntologyUpdate.vue
@@ -1,0 +1,91 @@
+<template>
+        <v-card>
+            <v-card-title>
+                <span class="headline">{{$t("ontologyUpdate.formTitle")}}</span>
+            </v-card-title>
+
+            <v-card-text>
+                <error-banner :message="errorMessage"></error-banner>
+                <success-banner :message="successMessage"></success-banner>
+                <v-container>
+                    <v-row>
+                        <v-col :cols="12">
+
+                            <v-form
+                                    ref="form"
+                                    lazy-validation
+                            >
+                              <v-file-input 
+                                @change="addFile"
+                                :rules="[v => !!v || 'Please select one']">
+                                <template v-slot:label>
+                                  .owl File
+                                </template>
+                                <template v-slot:append-outer><info-tooltip :message="$t('containers.owlFileHelp')"></info-tooltip> </template>
+                              </v-file-input>
+                              <v-row class="my-8 mx-0" align="center">
+                                <v-divider></v-divider>
+                                <span class="px-2">or</span>
+                                <v-divider></v-divider>
+                              </v-row>
+                              <v-text-field v-model="owlFilePath"
+                                :rules="[v => !!v || 'Please select one']">
+                                <template v-slot:label>
+                                  URL to .owl File
+                                </template>
+                                <template slot="append-outer"><info-tooltip :message="$t('containers.owlUrlHelp')"></info-tooltip> </template>
+                              </v-text-field>
+                            </v-form>
+                        </v-col>
+                    </v-row>
+                </v-container>
+            </v-card-text>
+
+            <v-card-actions>
+                <v-spacer></v-spacer>
+              <v-btn color="blue darken-1" text @click="updateContainer" ><span v-if="!loading">{{$t("home.save")}}</span>
+                <span v-if="loading"><v-progress-circular indeterminate></v-progress-circular></span>
+              </v-btn>
+            </v-card-actions>
+        </v-card>
+</template>
+
+<script lang="ts">
+import {Component, Prop, Vue} from 'vue-property-decorator'
+
+@Component
+export default class OntologyUpdate extends Vue {
+    @Prop({required: true})
+    readonly containerID!: string;
+
+    errorMessage = ""
+    successMessage = ""
+    loading = false
+    owlFilePath = ""
+    owlFile: File | null = null
+
+    addFile(file: File) {
+      this.owlFile = file
+    }
+
+    updateContainer() {
+      this.loading = true
+
+      if(this.owlFile || this.owlFilePath !== "") {
+        this.$client.updateContainerFromImport(this.containerID, this.owlFile, this.owlFilePath)
+            .then(() => {
+              this.loading = false
+              this.successMessage = "Container updated successfully"
+              this.errorMessage = ""
+            })
+            .catch(e => {
+              this.loading = false
+              this.errorMessage = e
+            })
+      } else {
+        this.errorMessage = "Please select either an ontology file or valid URL to an ontology file"
+        this.loading = false
+      }
+    }
+}
+</script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change includes a new page under the `Taxonomy` section for updating a container via an ontology file (file or URL to file). It also includes some minor bug fixes:

- Corrected reference to `create-container-dialog` on container administration
- Removed `item-key` props on Metatypes and MetatypeRelationships to remove related errors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
UI behaves as expected and container can be updated successfully

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
