### PR TITLE
Adds the type_mapping_id field to the payload sent by the UI on type …

### DIFF
--- a/web_ui/src/api/types.ts
+++ b/web_ui/src/api/types.ts
@@ -194,6 +194,7 @@ export type TypeMappingTransformationPayloadT = {
     unique_identifier_key?: string;
     on_conflict?: "create" | "update" | "ignore";
     keys: TypeMappingTransformationKeyMapping[];
+    type_mappping_id: string;
 }
 
 export type UserContainerInviteT = {

--- a/web_ui/src/components/transformationDialog.vue
+++ b/web_ui/src/components/transformationDialog.vue
@@ -808,6 +808,7 @@ export default class TransformationDialog extends Vue {
 
     payload.conditions = this.conditions
     payload.keys = this.propertyMapping
+    payload.type_mapping_id = this.typeMappingID
     if(this.uniqueIdentifierKey) payload.unique_identifier_key = this.uniqueIdentifierKey
     if(this.rootArray) payload.root_array = this.rootArray
 


### PR DESCRIPTION
…mapping updates

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Type mappings were not being updated properly due to the cache not being erased correctly on update. The type_mapping_id property was not coming through the UI payload to Update TypeTransformations. This field has been added to the corresponding parts of the UI and functionality works as expected now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested in UI


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
