### PR TITLE
Allow null values for non-required keys of a metatype

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
   "watch": ["src"],
   "ext": "ts,hbs",
-  "exec": "ts-node --files -r dotenv/config ./src/main.ts"
+  "exec": "tsc && copyfiles -u 1 \"./src/**/*.hbs\" ./dist && copyfiles -u 1 \"./src/assets/**\" ./dist && node -r dotenv/config ./dist/main.js"
 }

--- a/src/data_storage/graph/node_storage.ts
+++ b/src/data_storage/graph/node_storage.ts
@@ -159,6 +159,11 @@ export default class NodeStorage extends PostgresStorage{
                     ns[n].graph_id = graphID;
                     ns[n].container_id = containerID;
 
+                    // grab metatype_name if it was not supplied
+                    if (typeof ns[n].metatype_name === 'undefined') {
+                        ns[n].metatype_name = (await MetatypeStorage.Instance.Retrieve(ns[n].metatype_id)).value.name;
+                    }
+
                     ns[n].id = super.generateUUID();
                     queries.push(...NodeStorage.createOrUpdateStatement(ns[n]))
 

--- a/src/types/metatype_keyT.ts
+++ b/src/types/metatype_keyT.ts
@@ -53,29 +53,29 @@ export function CompileMetatypeKeys (mKeys: MetatypeKeyT[] | MetatypeRelationshi
     (mKeys as (MetatypeKeyT| MetatypeRelationshipKeyT)[]).map((key) => {
         switch(key.data_type) {
             case "number": {
-                (key.required) ? output[key.property_name] = t.number : partialOutput[key.property_name] = t.number;
+                (key.required) ? output[key.property_name] = t.number : partialOutput[key.property_name] = t.union([t.number, t.null]);
                 break;
             }
 
             case "date" : {
-                (key.required) ?  output[key.property_name] = t.string : partialOutput[key.property_name] = t.string;
+                (key.required) ?  output[key.property_name] = t.string : partialOutput[key.property_name] = t.union([t.null, t.string]);
                 break;
             }
 
             case "string" : {
-                (key.required) ? output[key.property_name] = t.string : partialOutput[key.property_name] = t.string;
+                (key.required) ? output[key.property_name] = t.string : partialOutput[key.property_name] = t.union([t.null, t.string]);
                 break;
             }
 
             case "boolean": {
-                (key.required) ? output[key.property_name] = t.boolean : partialOutput[key.property_name] = t.boolean;
+                (key.required) ? output[key.property_name] = t.boolean : partialOutput[key.property_name] = t.union([t.null, t.boolean]);
                 break;
             }
 
             case "enumeration": {
                 // if we don't have options, enum will default to a string value
                 if (key.options === undefined) {
-                    output[key.property_name] = t.string;
+                    output[key.property_name] = t.union([t.null, t.string]);
                     break;
                 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change includes a few updates:
- Allows null values for keys of a metatype (node properties) when the key is not required
- Adds the metatype_name value to the node update statement
- Alters the nodemon command to ensure typescript is recompiled correctly when using the command `npm run watch`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
