### PR TITLE
Allow user to set request body size limit with sane default

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,6 +1,9 @@
 # express.js application configuration
 SERVER_PORT=8090
 ROOT_ADDRESS=http://localhost:8090
+# the maximum size in megabytes of request bodies sent to Deep Lynx
+# requests with payloads over this limit will return a 413
+MAX_REQUEST_BODY_SIZE=50
 
 # there are various processes that look for other compiled typescript files
 PROJECT_DIR=./dist

--- a/src/http_server/routes/router.ts
+++ b/src/http_server/routes/router.ts
@@ -74,7 +74,7 @@ export class Router {
 
   public mount() {
     // DO NOT REMOVE - this is required for some auth methods to work correctly
-    this.app.use(express.urlencoded({ extended: false }));
+    this.app.use(express.urlencoded({ extended: false, limit: `${Config.max_request_body_size}mb` }));
 
     // single, raw endpoint for a health check
     this.app.get("/health", (req: express.Request, res: express.Response, next: express.NextFunction) => {
@@ -128,7 +128,7 @@ export class Router {
       origin: '*'
     }))
 
-      this.app.use(express.json());
+      this.app.use(express.json({limit: `${Config.max_request_body_size}mb`}));
 
     // basic session storage to postgres - keep in mind that this is currently
     // not used. It's here to facilitate future extension of the application and

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -40,6 +40,7 @@ export class Config {
 
   private readonly _server_port: string;
   private readonly _log_level: string;
+  private readonly _max_request_body_size: string;
 
   private readonly  _basic_user: string;
   private readonly _basic_password: string;
@@ -113,6 +114,7 @@ export class Config {
 
     this._server_port = process.env.SERVER_PORT || "8090";
     this._log_level = process.env.LOG_LEVEL || "debug";
+    this._max_request_body_size = process.env.MAX_REQUEST_BODY_SIZE || "50"
     this._session_secret = process.env.SESSION_SECRET || "changeme";
     this._basic_user = process.env.BASIC_USER || "";
     this._basic_password = process.env.BASIC_PASSWORD || "";
@@ -270,6 +272,10 @@ export class Config {
 
   get log_level(): string {
     return this._log_level
+  }
+
+  get max_request_body_size(): string {
+    return this._max_request_body_size
   }
 
   get basic_user(): string {


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Express defaults to 100Kb sizes for request bodies, a config setting must be provided to allow a user to alter this default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested via API requests of various sizes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
