### PR TITLE
readable report names

### DIFF
--- a/server/NodeLibraries/deeplynx/src/timeseries/query.rs
+++ b/server/NodeLibraries/deeplynx/src/timeseries/query.rs
@@ -113,7 +113,7 @@ pub async fn process_query(
     napi::Error::from_reason("uploadPath is not set in connection string".to_string())
   })?;
 
-  let file_name = format!("{}_{}_{}.csv", uuid, report_id, now.timestamp_millis());
+  let file_name = format!("{}_report_{}_{}.csv", uuid, report_id, now.timestamp_millis());
 
   let root_upload_path = match provider.as_str() {
     "filesystem" => {
@@ -173,6 +173,7 @@ pub async fn process_query(
     "file_size": file_size as f64 / 1000.00,
     "file_path": format!("{upload_path}/"),
     "adapter": provider,
+    "uuid": format!("{uuid}_"),
   });
 
   let metadata_res_json = serde_json::to_string(&result_metadata).map_err(|e| {

--- a/server/src/data_access_layer/repositories/data_warehouse/data/report_query_repository.ts
+++ b/server/src/data_access_layer/repositories/data_warehouse/data/report_query_repository.ts
@@ -173,11 +173,14 @@ export default class ReportQueryRepository extends Repository implements Reposit
             // create a file record in the DB
             const file = new File({
                 container_id: containerID,
-                file_name: parsedResults.file_name,
+                file_name: parsedResults.file_name.split(parsedResults.uuid)[1],
                 file_size: parsedResults.file_size,
                 adapter: parsedResults.adapter,
-                adapter_file_path: parsedResults.file_path
+                adapter_file_path: parsedResults.file_path,
+                short_uuid: parsedResults.uuid,
+                timeseries: true
             });
+
             const fileCreated = await this.#fileMapper.Create(user.id!, file);
 
             // if there's an error with file record creation, set report status to "error"


### PR DESCRIPTION
## Description

Adjust timeseries report names to be human readable.
Old: `<uuid>_<reportID>_<timestampMS>`
New: `report_<reportID>_<timestampMS>`

## Motivation and Context

More intuitive file names

## How Has This Been Tested?

Tested locally using both filesystem and azure storage systems. Confirmed that reports can be uploaded, downloaded and deleted properly.

## Screenshots (if appropriate):

<img width="1333" alt="image" src="https://github.com/user-attachments/assets/8df4f0e8-648d-49b1-8c5d-260ebc3b55b1">

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
