### PR TITLE
preserve data sources in export/import

### DIFF
--- a/server/src/data_access_layer/mappers/data_warehouse/import/data_source_mapper.ts
+++ b/server/src/data_access_layer/mappers/data_warehouse/import/data_source_mapper.ts
@@ -196,7 +196,8 @@ export default class DataSourceMapper extends Mapper {
             data_format,
             name,
             created_by,
-            modified_by) VALUES %L RETURNING *`;
+            modified_by,
+            old_id) VALUES %L RETURNING *`;
         const values = sources.map((source) => [
             source.container_id,
             source.adapter_type,
@@ -206,6 +207,7 @@ export default class DataSourceMapper extends Mapper {
             source.name,
             userID,
             userID,
+            source.old_id ? source.old_id : null,
         ]);
 
         return format(text, values);

--- a/server/src/data_access_layer/migrations/086_datasource_old_ids.sql
+++ b/server/src/data_access_layer/migrations/086_datasource_old_ids.sql
@@ -1,0 +1,1 @@
+ALTER TABLE data_sources ADD COLUMN old_id bigint DEFAULT NULL;

--- a/server/src/data_access_layer/repositories/data_warehouse/etl/type_mapping_repository.ts
+++ b/server/src/data_access_layer/repositories/data_warehouse/etl/type_mapping_repository.ts
@@ -481,18 +481,13 @@ export default class TypeMappingRepository extends Repository implements Reposit
                 typeMapping.transformations[i].modified_by = undefined;
                 typeMapping.transformations[i].modified_at = undefined;
 
-                // wipe the metatypeIDs in the edge connection params if there are any as well as data sources and node ids
+                // wipe the metatypeIDs in the edge connection params if there are any as well as node ids
                 // wipe only if they are VALUES not keys, keys will change as the data changes
                 if (typeMapping.transformations[i].origin_parameters) {
                     for (const j in typeMapping.transformations[i].origin_parameters!) {
                         if (typeMapping.transformations[i].origin_parameters![j].type)
                             switch (typeMapping.transformations[i].origin_parameters![j].type) {
                                 case 'metatype_id': {
-                                    typeMapping.transformations[i].origin_parameters![j].value = undefined;
-                                    break;
-                                }
-
-                                case 'data_source': {
                                     typeMapping.transformations[i].origin_parameters![j].value = undefined;
                                     break;
                                 }
@@ -514,11 +509,6 @@ export default class TypeMappingRepository extends Repository implements Reposit
                         if (typeMapping.transformations[i].destination_parameters![j].type)
                             switch (typeMapping.transformations[i].destination_parameters![j].type) {
                                 case 'metatype_id': {
-                                    typeMapping.transformations[i].destination_parameters![j].value = undefined;
-                                    break;
-                                }
-
-                                case 'data_source': {
                                     typeMapping.transformations[i].destination_parameters![j].value = undefined;
                                     break;
                                 }

--- a/server/src/data_access_layer/repositories/data_warehouse/import/data_source_repository.ts
+++ b/server/src/data_access_layer/repositories/data_warehouse/import/data_source_repository.ts
@@ -199,6 +199,9 @@ export default class DataSourceRepository extends Repository implements Reposito
                 return Promise.resolve(Result.Failure('Data source provided in import with invalid format. Please review.'));
             }
 
+            // grab the old ID from the data source record to make mappings that include data sources easier to process
+            const oldID = source.DataSourceRecord.id!;
+
             const dataSourceRecord = plainToClass(DataSourceRecord, source.DataSourceRecord as object);
 
             const dataSource = await this.#factory.fromDataSourceRecord(dataSourceRecord);
@@ -214,6 +217,8 @@ export default class DataSourceRepository extends Repository implements Reposito
                 dataSource.DataSourceRecord.id = undefined;
             }
 
+            // set old_id on the new DataSourceRecord
+            dataSource.DataSourceRecord.old_id = oldID;
             dataSource.DataSourceRecord.container_id = containerID;
             dataSource.DataSourceRecord.active = false;
 
@@ -294,6 +299,11 @@ export default class DataSourceRepository extends Repository implements Reposito
 
     archived(value: boolean) {
         super.query('archived', 'eq', value);
+        return this;
+    }
+
+    oldID(operator:string, value: any) {
+        super.query('old_id', operator, value);
         return this;
     }
 

--- a/server/src/domain_objects/data_warehouse/import/data_source.ts
+++ b/server/src/domain_objects/data_warehouse/import/data_source.ts
@@ -404,6 +404,9 @@ export default class DataSourceRecord extends BaseDomainClass {
     @IsBoolean()
     archived = false;
 
+    @IsOptional()
+    old_id?: string;
+
     @ValidateNested()
     @Type(() => BaseDataSourceConfig, {
         keepDiscriminatorProperty: true,
@@ -445,6 +448,7 @@ export default class DataSourceRecord extends BaseDomainClass {
         status_message?: string;
         data_retention_days?: number;
         archived?: boolean;
+        old_id?: string;
     }) {
         super();
         this.config = new StandardDataSourceConfig();
@@ -460,6 +464,7 @@ export default class DataSourceRecord extends BaseDomainClass {
             if (input.status_message) this.status_message = input.status_message;
             if (input.data_retention_days) this.config.data_retention_days = input.data_retention_days;
             if (input.archived) this.archived = input.archived;
+            if (input.old_id) this.old_id = input.old_id;
         }
     }
 }


### PR DESCRIPTION
## Description

Preserve data sources in export/import or assume data sources so mappings work on import

## Motivation and Context

Fixes #481 

## How Has This Been Tested?

Tested an import with [missing data source IDs](https://github.com/user-attachments/files/17332379/DataSourcesNoID.json), as well as one with [data source IDs filled in](https://github.com/user-attachments/files/17332380/DataSourcesWithID.json). Tested exporting a mapping with data sources to confirm that IDs were preserved. 

## Screenshots (if appropriate):

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
