### PR TITLE
Remove DataHub from Helm and improve refresh script

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -17,11 +17,8 @@ dependencies:
 - name: airflow
   repository: https://airflow.apache.org/
   version: 1.14.0
-- name: datahub
-  repository: https://helm.datahubproject.io
-  version: 0.4.19
 - name: mlflow
   repository: https://charts.bitnami.com/bitnami
   version: 1.4.16
-digest: sha256:6ce3b5cc3d2fdd19e247e70adf8b7938a34f095cda2aaa3b99f395ff24298f0c
-generated: "2024-08-02T11:23:31.972755-06:00"
+digest: sha256:0ec882cefcbc92ee4533948bd6002e8e95f9d80d36c1143a53f5e568baf58599
+generated: "2024-11-07T16:11:17.37458-07:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -53,12 +53,6 @@ dependencies:
     condition: airflow.enabled
     tags:
       - digitalTwin
-  - name: datahub
-    version: 0.4.19
-    repository: https://helm.datahubproject.io
-    condition: datahub.enabled
-    tags:
-      - digitalTwin
   - name: mlflow
     version: 1.4.16
     repository: https://charts.bitnami.com/bitnami

--- a/chart/helm-refresh.sh
+++ b/chart/helm-refresh.sh
@@ -1,5 +1,38 @@
 #!/bin/bash
 
+dependencies='false'
+help='false'
+pvc='false'
+timeout="5m0s"
+
+while getopts dpht: flag
+do
+    case "${flag}" in
+        d) dependencies='true';;
+        p) pvc='true';;
+        t) timeout=${OPTARG};;
+        h) help='true';;
+    esac
+done
+
+if $help; then
+  printf "This script uninstalls a helm release (named \"dl1\" by default), "
+  printf "deletes all persistent volume claims if passed the p option, "
+  printf "deletes any old deeplynx helm pacakges, "
+  printf "updates helm dependencies if passed the d option, creates a new "
+  printf "helm package, and then installs the package."
+  printf "\n\n"
+  printf "Options:"
+  printf "\n"
+  printf "    -h Show this help\n"
+  printf "    -d Update helm dependencies\n"
+  printf "    -t Provide install timeout in the form XmYs where X is the number of minutes\n"
+  printf "           and Y is the number of seconds. Default 5m0s.\n"
+  printf "    -p Delete persistent volume claims\n"
+
+  exit 0
+fi
+
 error_occurred=false
 
 printf "Refreshing helm release...\n\n"
@@ -9,24 +42,35 @@ helm uninstall dl1
 
 printf "\n"
 
-# delete persistnce volume claims
-kubectl delete pvc --all
-if [ $? -ne 0 ]; then error_occurred=true; fi
+# optionally delete persistent volume claims
+if $pvc; then
+  kubectl delete pvc --all
+  if [ $? -ne 0 ]; then error_occurred=true; fi
 
-printf "\n"
+  printf "\n"
+fi
 
 # delete any old deeplynx helm packages
 find . -name '*.tgz' -delete -maxdepth 1
 if [ $? -ne 0 ]; then error_occurred=true; fi
+
+# optionally update helm dependencies
+if $dependencies; then
+  printf "Updating helm dependencies...\n\n"
+
+  helm dependency update
+  if [ $? -ne 0 ]; then error_occurred=true; fi
+fi
 
 # create a new helm package
 helm package .
 if [ $? -ne 0 ]; then error_occurred=true; fi
 
 printf "\n"
+printf "Starting install with timeout $timeout\n\n"
 
 # install the new package
-helm install dl1 deeplynx-0.1.0.tgz
+helm install dl1 deeplynx-0.1.0.tgz --timeout ${timeout}
 if [ $? -ne 0 ]; then error_occurred=true; fi
 
 if $error_occurred; then

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -121,8 +121,6 @@ airflow:
       # whether to load example DAGs
       load_examples: true
 
-datahub:
-  enabled: false
 
 mlflow:
   enabled: false


### PR DESCRIPTION
## Description
Enables passing parameters to the Helm refresh script for controlling deletion of PVCs, timeout of install, and updating of dependencies. Removes DataHub from the Helm chart.

## Motivation and Context

## How Has This Been Tested?
Tested locally

## Screenshots (if appropriate):

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
