### PR TITLE
Fix/492 in operator

### DIFF
--- a/server/src/domain_objects/data_warehouse/etl/type_transformation.ts
+++ b/server/src/domain_objects/data_warehouse/etl/type_transformation.ts
@@ -413,6 +413,7 @@ export default class TypeTransformation extends BaseDomainClass {
         let results: Node[] | Edge[] = [];
         // if no root array, act normally
         if (!this.root_array) {
+
             let valid = false;
 
             // no conditions immediately equals true
@@ -430,6 +431,7 @@ export default class TypeTransformation extends BaseDomainClass {
  
             // we don't error out on a non-matching condition, simply pass the transformation by
             if (!valid) return new Promise((resolve) => resolve(Result.Success([])));
+
             const results = await this.generateResults(data);
 
             if (results.isError) {

--- a/server/src/domain_objects/data_warehouse/etl/type_transformation.ts
+++ b/server/src/domain_objects/data_warehouse/etl/type_transformation.ts
@@ -413,6 +413,23 @@ export default class TypeTransformation extends BaseDomainClass {
         let results: Node[] | Edge[] = [];
         // if no root array, act normally
         if (!this.root_array) {
+            let valid = false;
+
+            // no conditions immediately equals true
+            if (!this.conditions || this.conditions.length === 0) valid = true;
+
+            if (this.conditions) {
+                for (const condition of this.conditions) {
+                    const isValid = TypeTransformation.validTransformationCondition(condition, data.data as {[key: string]: any});
+                    if (isValid) {
+                        valid = true;
+                        break;
+                    }
+                }
+            }
+ 
+            // we don't error out on a non-matching condition, simply pass the transformation by
+            if (!valid) return new Promise((resolve) => resolve(Result.Success([])));
             const results = await this.generateResults(data);
 
             if (results.isError) {
@@ -790,6 +807,7 @@ export default class TypeTransformation extends BaseDomainClass {
         const value = this.getNestedValue(condition.key!, payload, index);
 
         if (!value) return false;
+
         let rootExpressionResult = TypeTransformation.compare(condition.operator!, value, condition.value);
 
         // handle subexpressions
@@ -823,8 +841,7 @@ export default class TypeTransformation extends BaseDomainClass {
             }
 
             case 'in': {
-                const expectedValues = expected.split(',');
-
+                const expectedValues = expected.split(',').map((item: string) => item.trim()); //split by comma and trim whitespace
                 return expectedValues.includes(value);
             }
 


### PR DESCRIPTION
## Description
Fix in type mapping transformation operator
## Motivation and Context
It was essentially only performing validation on root arrays so the fix both performs validation on the overall mapping, and then trims whitespace as it was dependent on the typescript .includes() function which doesn't account for whitespace depending on the format of the inputted in values payload.

## How Has This Been Tested?
Perform in type mapping transformation as well as analyze in data viewer
## Screenshots (if appropriate):

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
