### PR TITLE
Patch/docker

### DIFF
--- a/Dockerfiles/database/Dockerfile.local
+++ b/Dockerfiles/database/Dockerfile.local
@@ -23,8 +23,8 @@ RUN apk add --virtual .build-deps \
     git \
     build-base \
     postgresql18-dev \
-    clang19 \
-    llvm19 \
+    clang \
+    llvm \
     make
 
 # Install pgvector


### PR DESCRIPTION
## 🗣 Description

(From Jack C. originally)
Updates the Postgres Docker build dependencies to install the default `clang` and `llvm` packages instead of pinned versioned packages.

## 💭 Motivation and context

The local database image was failing while building pgvector because PostgreSQL expected `clang-21`, but the Dockerfile had older pinned LLVM/Clang packages. Using the default `apk` packages keeps `clang` and `llvm` aligned with the current Alpine/Postgres packages as a short-term fix.

A more permanent build approach will be handled separately.

## 🧪 Testing

Built the database image locally and confirmed the pgvector install step completes successfully:

```bash
docker build -t deeplynx-db -f Dockerfiles/database/Dockerfile.local .
```

## Link to GitHub Test Build

N/A

## ✅ Pre-approval checklist

- [x] Changes are limited to a single goal / jira ticket
- [x] Changes have been tested in a local build and in the docker app.